### PR TITLE
Fix "TypeError: Object of type 'float32' is not JSON serializable"

### DIFF
--- a/llama/LLMzip.py
+++ b/llama/LLMzip.py
@@ -167,7 +167,7 @@ class LLMzip_encode:
         df_out = {}
         df_out['$N_C$'] = [N_C]
         df_out['$N_T$'] = [N_T]
-        df_out['$H_{ub}$'] = [np.sum(-1*np.log2(probs_tok))/N_C]
+        df_out['$H_{ub}$'] = [str(np.sum(-1*np.log2(probs_tok))/N_C)]
         
         
         
@@ -181,7 +181,7 @@ class LLMzip_encode:
             df_out['Llama+zlib compressed file size'] = [len(ranks_compressed_bytes)*8]
             df_out['$\rho_{LLaMa+Zlib}$'] = [rho_RZ]
             
-        df_out['$\rho_{TbyT}$'] = [np.sum(np.ceil(-1*np.log2(probs_tok)))/N_C]
+        df_out['$\rho_{TbyT}$'] = [str(np.sum(np.ceil(-1*np.log2(probs_tok)))/N_C)]
         
         if (self.compression_alg == 'ArithmeticCoding')or(self.compression_alg =='both'):
             b_ind = 1


### PR DESCRIPTION
Reason: some of the values in the dict are of type numpy.float32. The json module cannot serialize numpy.float32 values.

Fix: converting numpy.float32 to str.

According to [https://docs.python.org/3/library/json.html](https://docs.python.org/3/library/json.html):

> Keys in key/value pairs of JSON are always of the type str. When a dictionary is converted into JSON, all the keys of the dictionary are coerced to strings. As a result of this, if a dictionary is converted into JSON and then back into a dictionary, the dictionary may not equal the original one. That is, loads(dumps(x)) != x if x has non-string keys.

So it should be OK to convert float32 to str.

This should fix #6. Tested with examples given in README. 